### PR TITLE
Fix order of BG and FG color in reading pattern fill.

### DIFF
--- a/root-types/Stylesheet.ts
+++ b/root-types/Stylesheet.ts
@@ -753,8 +753,8 @@ module Stylesheet {
             var fgColorElem = xmlDoc.queryOneChild(elem, "fgColor", false);
 
             return {
-                bgColor: bgColorElem ? Color.read(xmlDoc, bgColorElem, "bgColor") : null,
                 fgColor: fgColorElem ? Color.read(xmlDoc, fgColorElem, "fgColor") : null,
+                bgColor: bgColorElem ? Color.read(xmlDoc, bgColorElem, "bgColor") : null,
                 patternType: <OpenXml.ST_PatternType | null>xmlDoc.attrString(elem, "patternType"),
             };
         },


### PR DESCRIPTION
Excel pattern fill formats require the fgColor to come before the bgColor in order to work properly.